### PR TITLE
プレビュー画面の導入

### DIFF
--- a/app/assets/stylesheets/drafts/_drafts.scss
+++ b/app/assets/stylesheets/drafts/_drafts.scss
@@ -134,6 +134,16 @@
           margin-left: 10px;
           margin-top: 40px;
         }
+        .preview__btn {
+          font-size: 1.8rem;
+          display: inline-block;
+          padding: 0.5em 1em;
+          text-decoration: none;
+          background: #2431ca82;
+          color: #FFF;
+          border-radius: 3px;
+          margin-top: 10px;
+        }
       }
     }
   }

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -1,6 +1,6 @@
 class DraftsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_article, only: [:edit, :update, :release]
+  before_action :set_article, only: [:show, :edit, :update, :release]
   def index
     @articles = Article.includes(:user).order("created_at DESC")
   end
@@ -12,6 +12,9 @@ class DraftsController < ApplicationController
       format.html
       format.json
     end
+  end
+
+  def show
   end
 
   def create

--- a/app/views/drafts/_article.html.haml
+++ b/app/views/drafts/_article.html.haml
@@ -13,3 +13,4 @@
     =link_to '削除', "#", class: "destroy__btn" if admin_user?(current_user)
     =link_to '公開', release_draft_path(article), class: "release__btn" if admin_user?(current_user) && article.release == false
     =link_to '済', "#", class: "released__btn" if admin_user?(current_user) && article.release == true
+    =link_to 'プレビュー', draft_path(article), class: "preview__btn" if is_your_article?(article, current_user) or admin_user?(current_user)

--- a/app/views/drafts/show.html.haml
+++ b/app/views/drafts/show.html.haml
@@ -1,0 +1,9 @@
+= render partial: 'shared/header'
+.release-article
+  .release-article__content
+    %h1.release-article__content__title
+      = @article.title
+    %p.release-article__content__description
+      = @article.description
+    %p.release-article__content__body
+      = markdown(@article.body).html_safe

--- a/app/views/drafts/show.html.haml
+++ b/app/views/drafts/show.html.haml
@@ -1,4 +1,7 @@
-= render partial: 'shared/header'
+%header.drafts-header
+  = image_tag('logo.png')
+  %h1.drafts-header__title
+    Preview
 .release-article
   .release-article__content
     %h1.release-article__content__title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'articles#index'
   resources :articles, only: [:show]
   resources :users, only: [:edit, :update]
-  resources :drafts, only: [:index, :new, :create, :edit, :update] do
+  resources :drafts, only: [:index, :show, :new, :create, :edit, :update] do
     member do
       get :release
     end


### PR DESCRIPTION
## WHAT
プレビュー画面の導入

## WHY
ライターが運営側に記事を納品する前にrelease後の記事の見た目を確認することができる。マークダウンの崩れなどをチェックできる。